### PR TITLE
Handle truncated YCbCr buffers

### DIFF
--- a/rotate_odd_test.go
+++ b/rotate_odd_test.go
@@ -1,0 +1,28 @@
+package imaging
+
+import (
+	"image"
+	"testing"
+)
+
+func TestRotate90_YCbCrOddHeight(t *testing.T) {
+	yStride := 288
+	cStride := 144
+	width := 288
+	height := 147
+	im := &image.YCbCr{
+		Y:              make([]uint8, yStride*height),
+		Cb:             make([]uint8, (cStride*height)/2),
+		Cr:             make([]uint8, (cStride*height)/2),
+		YStride:        yStride,
+		CStride:        cStride,
+		SubsampleRatio: image.YCbCrSubsampleRatio420,
+		Rect:           image.Rect(0, 0, width, height),
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Rotate90 panicked: %v", r)
+		}
+	}()
+	_ = Rotate90(im)
+}

--- a/scanner.go
+++ b/scanner.go
@@ -198,9 +198,17 @@ func (s *scanner) scan(x1, y1, x2, y2 int, dst []uint8) {
 					ic = img.COffset(x, y)
 				}
 
-				yy1 := int32(img.Y[iy]) * 0x10101
-				cb1 := int32(img.Cb[ic]) - 128
-				cr1 := int32(img.Cr[ic]) - 128
+				var yy1 int32
+				if iy < len(img.Y) {
+					yy1 = int32(img.Y[iy]) * 0x10101
+				}
+				var cb1, cr1 int32
+				if ic < len(img.Cb) {
+					cb1 = int32(img.Cb[ic]) - 128
+				}
+				if ic < len(img.Cr) {
+					cr1 = int32(img.Cr[ic]) - 128
+				}
 
 				r := yy1 + 91881*cr1
 				if uint32(r)&0xff000000 == 0 {


### PR DESCRIPTION
## Summary
- avoid panic in scanner when YCbCr planes are shorter than expected
- add regression test for Rotate90 on an odd-height YCbCr image

## Testing
- `go test ./...`