### PR TITLE
#159 Fix YCbCr index out of bounds for odd dimensions - Add bounds checkin…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+test_reproduce/test_reproduce

--- a/scanner.go
+++ b/scanner.go
@@ -176,6 +176,10 @@ func (s *scanner) scan(x1, y1, x2, y2 int, dst []uint8) {
 
 		hy := img.Rect.Min.Y / 2
 		hx := img.Rect.Min.X / 2
+		
+		// Calculate the bounds for chroma arrays
+		chromaMaxIndex := len(img.Cb) - 1
+		
 		for y := y1; y < y2; y++ {
 			iy := (y-img.Rect.Min.Y)*img.YStride + (x1 - img.Rect.Min.X)
 
@@ -196,6 +200,14 @@ func (s *scanner) scan(x1, y1, x2, y2 int, dst []uint8) {
 					ic = yBase + (x/2 - hx)
 				default:
 					ic = img.COffset(x, y)
+				}
+				
+				// Clamp the chroma index to be within bounds
+				if ic > chromaMaxIndex {
+					ic = chromaMaxIndex
+				}
+				if ic < 0 {
+					ic = 0
 				}
 
 				yy1 := int32(img.Y[iy]) * 0x10101

--- a/test_reproduce/go.mod
+++ b/test_reproduce/go.mod
@@ -1,0 +1,10 @@
+module test_reproduce
+
+go 1.23.0
+
+require (
+	github.com/disintegration/imaging v1.6.2 // indirect
+	golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8 // indirect
+)
+
+replace github.com/disintegration/imaging => ..

--- a/test_reproduce/go.sum
+++ b/test_reproduce/go.sum
@@ -1,0 +1,5 @@
+github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1ei82L+c=
+github.com/disintegration/imaging v1.6.2/go.mod h1:44/5580QXChDfwIclfc/PCwrr44amcmDAg8hxG0Ewe4=
+golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8 h1:hVwzHzIUGRjiF7EcUjqNxk3NCfkPxbDKRdnNE1Rpg0U=
+golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/test_reproduce/main.go
+++ b/test_reproduce/main.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"fmt"
+	"image"
+
+	"github.com/disintegration/imaging"
+)
+
+func Test() {
+	yStride := 288
+	cStride := 144
+	width := 288
+	height := 147
+
+	im := &image.YCbCr{
+		Y:              make([]uint8, yStride*height),
+		Cb:             make([]uint8, (cStride*height)/2),
+		Cr:             make([]uint8, (cStride*height)/2),
+		YStride:        yStride,
+		CStride:        yStride / 2,
+		SubsampleRatio: image.YCbCrSubsampleRatio420,
+		Rect: image.Rectangle{
+			Min: image.Point{
+				X: 0,
+				Y: 0,
+			},
+			Max: image.Point{
+				X: width,
+				Y: height,
+			},
+		},
+	}
+	imaging.Rotate90(im)
+}
+
+func TestOddDimensions() {
+	fmt.Println("Testing YCbCr with odd dimensions...")
+
+	// Test case 1: Original issue - height=147 (odd)
+	fmt.Print("Test 1 (height=147): ")
+	testCase1 := &image.YCbCr{
+		Y:              make([]uint8, 288*147),  // yStride * height
+		Cb:             make([]uint8, (144*147)/2), // (cStride * height) / 2
+		Cr:             make([]uint8, (144*147)/2),
+		YStride:        288,
+		CStride:        144,
+		SubsampleRatio: image.YCbCrSubsampleRatio420,
+		Rect: image.Rectangle{
+			Min: image.Point{X: 0, Y: 0},
+			Max: image.Point{X: 288, Y: 147},
+		},
+	}
+	imaging.Rotate90(testCase1)
+	fmt.Println("PASS")
+
+	// Test case 2: Width odd, height even
+	fmt.Print("Test 2 (width=289, height=146): ")
+	testCase2 := &image.YCbCr{
+		Y:              make([]uint8, 289*146),
+		Cb:             make([]uint8, (145*146)/2),
+		Cr:             make([]uint8, (145*146)/2),
+		YStride:        289,
+		CStride:        145,
+		SubsampleRatio: image.YCbCrSubsampleRatio420,
+		Rect: image.Rectangle{
+			Min: image.Point{X: 0, Y: 0},
+			Max: image.Point{X: 289, Y: 146},
+		},
+	}
+	imaging.Rotate90(testCase2)
+	fmt.Println("PASS")
+
+	// Test case 3: Both dimensions odd
+	fmt.Print("Test 3 (width=289, height=147): ")
+	testCase3 := &image.YCbCr{
+		Y:              make([]uint8, 289*147),
+		Cb:             make([]uint8, (145*147)/2),
+		Cr:             make([]uint8, (145*147)/2),
+		YStride:        289,
+		CStride:        145,
+		SubsampleRatio: image.YCbCrSubsampleRatio420,
+		Rect: image.Rectangle{
+			Min: image.Point{X: 0, Y: 0},
+			Max: image.Point{X: 289, Y: 147},
+		},
+	}
+	imaging.Rotate90(testCase3)
+	fmt.Println("PASS")
+
+	// Test case 4: Small odd dimensions
+	fmt.Print("Test 4 (width=3, height=5): ")
+	testCase4 := &image.YCbCr{
+		Y:              make([]uint8, 3*5),
+		Cb:             make([]uint8, (2*5)/2),
+		Cr:             make([]uint8, (2*5)/2),
+		YStride:        3,
+		CStride:        2,
+		SubsampleRatio: image.YCbCrSubsampleRatio420,
+		Rect: image.Rectangle{
+			Min: image.Point{X: 0, Y: 0},
+			Max: image.Point{X: 3, Y: 5},
+		},
+	}
+	imaging.Rotate90(testCase4)
+	fmt.Println("PASS")
+
+	// Test other transformations too
+	fmt.Print("Test 5 (Rotate180): ")
+	imaging.Rotate180(testCase1)
+	fmt.Println("PASS")
+
+	fmt.Print("Test 6 (Rotate270): ")
+	imaging.Rotate270(testCase1)
+	fmt.Println("PASS")
+
+	fmt.Print("Test 7 (FlipH): ")
+	imaging.FlipH(testCase1)
+	fmt.Println("PASS")
+
+	fmt.Print("Test 8 (FlipV): ")
+	imaging.FlipV(testCase1)
+	fmt.Println("PASS")
+
+	fmt.Println("All tests passed!")
+}
+
+func main() {
+	Test()
+	TestOddDimensions()
+} 


### PR DESCRIPTION
…g for chroma array access in scanner.go - Prevents panic when processing YCbCr images with odd dimensions in 420 subsampling - Clamp chroma indices to valid range instead of crashing - Add comprehensive test cases for various odd dimension scenarios

<img width="600" alt="image" src="https://github.com/user-attachments/assets/185cc300-397a-4704-a59f-ec34fdaa6035" />

<img width="600" alt="image" src="https://github.com/user-attachments/assets/4a7f95dc-160c-43b7-aed8-d8d91ea70a51" />

